### PR TITLE
Suggestion: make header.html links open in new tab/window

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,7 @@
         <a href="https://noiseehc.github.io/c64wrd">{{ site.description | default: site.github.project_tagline }}</a>
     </h1>
     <ul>
-        <li><a href="https://csdb.dk/forums/?roomid=11&topicid=162590">Discuss On <strong>CSDb</strong></a></li>
-        <li><a href="{{ site.github.repository_url }}">View On <strong>GitHub</strong></a></li>
+        <li><a target="_blank" href="https://csdb.dk/forums/?roomid=11&topicid=162590">Discuss On <strong>CSDb</strong></a></li>
+        <li><a target="_blank" href="{{ site.github.repository_url }}">View On <strong>GitHub</strong></a></li>
     </ul>
 </header>


### PR DESCRIPTION
I feel like it has become the norm to open github / discussion links in a new tab / window by default, so I was a little confused when I clicked the github link on https://noiseehc.github.io/c64wrd/ and it took over the website's tab.